### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A UIView that will zoom into its parent view. It can be implemented with only th
 
 ![alt text](http://imgur.com/9eIAsbe.png "UIView that will zoom into its parent view")
 
-##How to
+## How to
 
 Initialize the zoom view anywhere in a view. 
 
@@ -14,12 +14,12 @@ Initialize the zoom view anywhere in a view.
     [zoomView setDragingEnabled:NO];
     [self.view addSubview:zoomView];
     
-####Options:
+#### Options:
   
   1. `setZoomScale:` Here you can set the zoom value (Standard = 2.0)
   2. `setDragingEnabled:` Here you can decide wether the user can drag the zoom view around or if it is static. If static, then the user can touch throuch this view which is nice if you place it over a UITableView and still want to scroll.
 
-####Important:
+#### Important:
   
   `[zoomview setNeedsDisplay]` must be called everytime you want to update the zoom view. For example the zoom view is placed over a UITableView and you want a live zoom when scrolling, then you must implement this in the `scrollViewDidScroll:` method.
   Exception here is when dragging.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
